### PR TITLE
toRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ require('auto-require')(options)
 // gulp and notify avaliable globaly (only)
 ```
 
+#### 7. toRoot
+
+You can import all functions of module into root object.
+
+```js
+const options = {
+	only: ['request'],
+	toRoot: ['request']
+}
+
+const $ = require('auto-require')(options)
+
+// $.get, $.post, $.head (all function from request). But not $.request
+```
+
+
 ## What it does?
 
 It takes all modules in your `node_modules` folder by default using data from `package.json` and exports it as one module.
@@ -120,17 +136,17 @@ Quick example
 ## What about jQuery or build tools?
 
 No, you'll not need to write full module name.
-The first part of the module name will be cut in this case.    
-For example we have `gulp-pug` module. How we can access it?  
-Actually it's pretty straightforward - via `$.pug`.  
-As you can see the first part of the `gulp-pug` has been cut.  
+The first part of the module name will be cut in this case.
+For example we have `gulp-pug` module. How we can access it?
+Actually it's pretty straightforward - via `$.pug`.
+As you can see the first part of the `gulp-pug` has been cut.
 
 This tool works fine with `gulp`, `grunt`, `broccoli`.
 
 ## Other access examples
 
 - `gulp` via `$.gulp`
-- `gulp-plumber` via `$.plumber` 
+- `gulp-plumber` via `$.plumber`
 - `gulp-inline-css` via `$.inlineCss`
 - `grunt` via `$.grunt`
 - `grunt-shell` via `$.shell`

--- a/index.js
+++ b/index.js
@@ -12,6 +12,15 @@ module.exports = function autoRequire (options) {
   const packageNames = makePackageNames(map.packages)
   const modules = requireModules(map.fullPaths)
   const collection = zipObject(packageNames, modules)
+  if (options.toRoot) {
+    options.toRoot.map(module => {
+      Object.keys(collection[module]).map(key => {
+        collection[key] = collection[module][key]
+      })
+      
+      delete collection[module]
+    })
+  }
   if (globaly) {
     Object.keys(collection).forEach(x => {
       global[x] = collection[x]

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -47,6 +47,7 @@ module.exports = function parseOptions (options) {
 
   return {
     schema: zipObject(search, modules),
-    globaly: globaly
+    globaly: globaly,
+    toRoot: options.toRoot,
   }
 }

--- a/test/autoRequire.js
+++ b/test/autoRequire.js
@@ -11,5 +11,24 @@ t.test('autoRequire', t => {
   t.ok(collection.eslint)
   t.deepEqual(collection.eslint, global.eslint)
   t.ok(Object.keys(collection).length)
+  
+  
+  
+  const collection2 = autoRequire({
+    toRoot: ['eslint']
+  })
+  
+  t.ok(collection2)
+  t.ok(collection2.lodashCamelcase)
+  t.ok(collection2.lodashZipobject)
+  
+  t.ok(! collection2.eslint)
+  t.ok(collection2.linter)
+  t.ok(collection2.CLIEngine)
+  t.ok(collection2.RuleTester)
+  t.ok(collection2.SourceCode)
+  
+  t.ok(Object.keys(collection2).length)
+  
   t.end()
 })


### PR DESCRIPTION
#### 7. toRoot

You can import all functions of module into root object.

```js
const options = {
	only: ['request'],
	toRoot: ['request']
}

const $ = require('auto-require')(options)

// $.get, $.post, $.head (all function from request). But not $.request
```